### PR TITLE
[FEAT] Add Terraform infrastructure code for ELK stack - PIT-468

### DIFF
--- a/terraform/01-namespace.tf
+++ b/terraform/01-namespace.tf
@@ -1,0 +1,23 @@
+# 1단계: 기본 인프라 (네임스페이스)
+# 이 파일을 먼저 적용: terraform apply -target=kubernetes_namespace.monitoring
+
+# Google Cloud 클라이언트 설정
+data "google_client_config" "current" {}
+
+# GKE 클러스터 정보 가져오기
+data "google_container_cluster" "main" {
+  name     = var.cluster_name
+  location = var.cluster_location
+  project  = var.project_id
+}
+
+# Kubernetes 네임스페이스 생성
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = var.namespace
+    labels = {
+      name = var.namespace
+      app  = "monitoring"
+    }
+  }
+}

--- a/terraform/02-elasticsearch.tf
+++ b/terraform/02-elasticsearch.tf
@@ -1,0 +1,19 @@
+# 2단계: Elasticsearch 배포
+# 이 파일을 적용: terraform apply -target=helm_release.elasticsearch
+
+# Elasticsearch 배포
+resource "helm_release" "elasticsearch" {
+  name       = "elasticsearch"
+  repository = "https://helm.elastic.co"
+  chart      = "elasticsearch"
+  version    = var.elasticsearch_version
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+
+  values = [
+    file("${path.module}/../helm-charts/elasticsearch/values.yaml")
+  ]
+
+  # values.yaml 파일을 사용하므로 set 구문 제거
+
+  depends_on = [kubernetes_namespace.monitoring]
+}

--- a/terraform/03-logstash.tf
+++ b/terraform/03-logstash.tf
@@ -1,0 +1,19 @@
+# 3단계: Logstash 배포
+# 이 파일을 적용: terraform apply -target=helm_release.logstash
+
+# Logstash 배포
+resource "helm_release" "logstash" {
+  name       = "logstash"
+  repository = "https://helm.elastic.co"
+  chart      = "logstash"
+  version    = var.logstash_version
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+
+  values = [
+    file("${path.module}/../helm-charts/logstash/values.yaml")
+  ]
+
+  # values.yaml 파일을 사용하므로 set 구문 제거
+
+  depends_on = [helm_release.elasticsearch]
+}

--- a/terraform/04-kibana.tf
+++ b/terraform/04-kibana.tf
@@ -1,0 +1,18 @@
+# 4단계: Kibana 배포
+# 이 파일을 적용: terraform apply -target=helm_release.kibana
+
+# Kibana 배포
+resource "helm_release" "kibana" {
+  name       = "kibana"
+  repository = "https://helm.elastic.co"
+  chart      = "kibana"
+  version    = var.kibana_version
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  timeout    = 300  # 5분
+
+  values = [
+    file("${path.module}/../helm-charts/kibana/values.yaml")
+  ]
+
+  depends_on = [helm_release.elasticsearch]
+}

--- a/terraform/05-filebeat.tf
+++ b/terraform/05-filebeat.tf
@@ -1,0 +1,18 @@
+# 5단계: Filebeat 배포
+# 이 파일을 적용: terraform apply -target=helm_release.filebeat
+
+# Filebeat 배포
+resource "helm_release" "filebeat" {
+  name       = "filebeat"
+  repository = "https://helm.elastic.co"
+  chart      = "filebeat"
+  version    = var.filebeat_version
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  timeout    = 300  # 5분
+
+  values = [
+    file("${path.module}/../helm-charts/filebeat/values.yaml")
+  ]
+
+  depends_on = [helm_release.logstash]
+}

--- a/terraform/monitoring.tfvars
+++ b/terraform/monitoring.tfvars
@@ -1,0 +1,76 @@
+# ELK Stack Terraform Variables
+# 실제 배포용 설정 파일
+
+# GKE 클러스터 설정
+cluster_name     = "pitterpetter-dev-cluster"
+cluster_location = "asia-northeast3-b"
+project_id       = "pitterpetter"
+
+# Kubernetes 설정
+namespace   = "monitoring"
+environment = "development"
+
+# ELK Stack 버전 (안정성 보장 버전)
+elasticsearch_version = "8.5.1"
+kibana_version       = "8.5.1"
+logstash_version     = "8.5.1"
+filebeat_version     = "8.5.1"
+
+# 도메인 설정
+kibana_domain       = "kibana.loventure.us"
+elasticsearch_domain = "loventure-elk-master.monitoring.svc.cluster.local"
+
+# 리소스 설정
+elasticsearch_resources = {
+  requests = {
+    cpu    = "1000m"
+    memory = "2Gi"
+  }
+  limits = {
+    cpu    = "2000m"
+    memory = "4Gi"
+  }
+}
+
+kibana_resources = {
+  requests = {
+    cpu    = "500m"
+    memory = "1Gi"
+  }
+  limits = {
+    cpu    = "1000m"
+    memory = "2Gi"
+  }
+}
+
+logstash_resources = {
+  requests = {
+    cpu    = "500m"
+    memory = "1Gi"
+  }
+  limits = {
+    cpu    = "1000m"
+    memory = "2Gi"
+  }
+}
+
+filebeat_resources = {
+  requests = {
+    cpu    = "100m"
+    memory = "200Mi"
+  }
+  limits = {
+    cpu    = "200m"
+    memory = "400Mi"
+  }
+}
+
+# 스토리지 설정
+elasticsearch_storage_class_name = "standard-rwo"
+elasticsearch_storage_size       = "20Gi"
+
+# Kibana Ingress TLS Secret 이름
+kibana_ingress_tls_secret_name = "loventure-tls-secret"
+
+# Elasticsearch CORS 허용 오리진
+elasticsearch_cors_allow_origin = "https://loventure.us, https://api.loventure.us, https://kibana.loventure.us"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,124 @@
+# 클러스터 정보
+output "cluster_name" {
+  description = "GKE 클러스터 이름"
+  value       = data.google_container_cluster.main.name
+}
+
+output "cluster_location" {
+  description = "GKE 클러스터 위치"
+  value       = data.google_container_cluster.main.location
+}
+
+output "cluster_endpoint" {
+  description = "GKE 클러스터 엔드포인트"
+  value       = data.google_container_cluster.main.endpoint
+}
+
+# 네임스페이스
+output "namespace" {
+  description = "Kubernetes 네임스페이스"
+  value       = kubernetes_namespace.monitoring.metadata[0].name
+}
+
+# Elasticsearch 정보
+output "elasticsearch_url" {
+  description = "Elasticsearch 내부 URL"
+  value       = "http://${var.elasticsearch_domain}:9200"
+}
+
+output "elasticsearch_external_url" {
+  description = "Elasticsearch 외부 접근 명령어"
+  value       = "kubectl port-forward svc/elasticsearch-master 9200:9200 -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+}
+
+output "elasticsearch_release" {
+  description = "Elasticsearch Helm release 정보"
+  value = {
+    name      = helm_release.elasticsearch.name
+    namespace = helm_release.elasticsearch.namespace
+    status    = helm_release.elasticsearch.status
+    version   = helm_release.elasticsearch.version
+  }
+}
+
+# Kibana 정보
+output "kibana_url" {
+  description = "Kibana URL"
+  value       = "https://${var.kibana_domain}"
+}
+
+output "kibana_release" {
+  description = "Kibana Helm release 정보"
+  value = {
+    name      = helm_release.kibana.name
+    namespace = helm_release.kibana.namespace
+    status    = helm_release.kibana.status
+    version   = helm_release.kibana.version
+  }
+}
+
+# Logstash 정보
+output "logstash_release" {
+  description = "Logstash Helm release 정보"
+  value = {
+    name      = helm_release.logstash.name
+    namespace = helm_release.logstash.namespace
+    status    = helm_release.logstash.status
+    version   = helm_release.logstash.version
+  }
+}
+
+# Filebeat 정보
+output "filebeat_release" {
+  description = "Filebeat Helm release 정보"
+  value = {
+    name      = helm_release.filebeat.name
+    namespace = helm_release.filebeat.namespace
+    status    = helm_release.filebeat.status
+    version   = helm_release.filebeat.version
+  }
+}
+
+# 모니터링 아키텍처
+output "monitoring_architecture" {
+  description = "모니터링 아키텍처"
+  value = {
+    log_collection   = "Filebeat"
+    log_processing   = "Logstash"
+    log_storage      = "Elasticsearch"
+    logs_analysis    = "ELK Stack (Kibana)"
+    metrics_analysis = "GMP (Google Cloud Console)"
+  }
+}
+
+# 로그 수집 서비스
+output "log_collection_services" {
+  description = "로그 수집 대상 서비스"
+  value = [
+    "loventure-prod-ai-service",
+    "loventure-prod-auth-service",
+    "loventure-prod-content-service",
+    "loventure-prod-course-service",
+    "loventure-prod-gateway",
+  ]
+}
+
+# 로그 인덱스 패턴
+output "log_index_pattern" {
+  description = "로그 인덱스 패턴"
+  value       = "loventure-logs-*"
+}
+
+# 유용한 명령어들
+output "deployment_commands" {
+  description = "유용한 배포 명령어들"
+  value = {
+    check_pods         = "kubectl get pods -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+    check_svcs         = "kubectl get svc -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+    check_ingress      = "kubectl get ingress -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+    elasticsearch_logs = "kubectl logs -f deployment/elasticsearch-master -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+    kibana_logs        = "kubectl logs -f deployment/kibana-kibana -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+    logstash_logs      = "kubectl logs -f deployment/logstash-logstash -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+    filebeat_logs      = "kubectl logs -f daemonset/filebeat -n ${kubernetes_namespace.monitoring.metadata[0].name}"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,206 @@
+# GKE 클러스터 설정
+variable "cluster_name" {
+  description = "GKE 클러스터 이름"
+  type        = string
+  default     = "pitterpetter-dev-cluster"
+}
+
+variable "cluster_location" {
+  description = "GKE 클러스터 위치"
+  type        = string
+  default     = "asia-northeast3-b"
+}
+
+variable "project_id" {
+  description = "Google Cloud 프로젝트 ID"
+  type        = string
+  default     = "pitterpetter"
+}
+
+# Kubernetes 설정
+variable "namespace" {
+  description = "Kubernetes 네임스페이스"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "environment" {
+  description = "환경 (development, staging, production)"
+  type        = string
+  default     = "development"
+}
+
+# ELK Stack 버전
+variable "elasticsearch_version" {
+  description = "Elasticsearch Helm chart 버전"
+  type        = string
+  default     = "8.5.1"
+}
+
+variable "kibana_version" {
+  description = "Kibana Helm chart 버전"
+  type        = string
+  default     = "8.5.1"
+}
+
+variable "logstash_version" {
+  description = "Logstash Helm chart 버전"
+  type        = string
+  default     = "8.5.1"
+}
+
+variable "filebeat_version" {
+  description = "Filebeat Helm chart 버전"
+  type        = string
+  default     = "8.5.1"
+}
+
+# 도메인 설정
+variable "kibana_domain" {
+  description = "Kibana 도메인"
+  type        = string
+  default     = "kibana.loventure.us"
+}
+
+variable "elasticsearch_domain" {
+  description = "Elasticsearch 내부 도메인"
+  type        = string
+  default     = "loventure-elk-master.monitoring.svc.cluster.local"
+}
+
+# 리소스 설정
+variable "elasticsearch_resources" {
+  description = "Elasticsearch 리소스 설정"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      cpu    = "1000m"
+      memory = "2Gi"
+    }
+    limits = {
+      cpu    = "2000m"
+      memory = "4Gi"
+    }
+  }
+}
+
+variable "kibana_resources" {
+  description = "Kibana 리소스 설정"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      cpu    = "500m"
+      memory = "1Gi"
+    }
+    limits = {
+      cpu    = "1000m"
+      memory = "2Gi"
+    }
+  }
+}
+
+variable "logstash_resources" {
+  description = "Logstash 리소스 설정"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      cpu    = "500m"
+      memory = "1Gi"
+    }
+    limits = {
+      cpu    = "1000m"
+      memory = "2Gi"
+    }
+  }
+}
+
+variable "filebeat_resources" {
+  description = "Filebeat 리소스 설정"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      cpu    = "100m"
+      memory = "200Mi"
+    }
+    limits = {
+      cpu    = "200m"
+      memory = "400Mi"
+    }
+  }
+}
+
+# 스토리지 설정
+variable "elasticsearch_storage_class_name" {
+  description = "Elasticsearch StorageClass 이름"
+  type        = string
+  default     = "standard-rwo"
+}
+
+variable "elasticsearch_storage_size" {
+  description = "Elasticsearch 스토리지 크기"
+  type        = string
+  default     = "20Gi"
+}
+
+# Kibana Ingress TLS Secret 이름
+variable "kibana_ingress_tls_secret_name" {
+  description = "Kibana Ingress TLS Secret 이름"
+  type        = string
+  default     = "loventure-tls-secret"
+}
+
+# Elasticsearch CORS 허용 오리진
+variable "elasticsearch_cors_allow_origin" {
+  description = "Elasticsearch CORS 허용 오리진"
+  type        = string
+  default     = "https://loventure.us, https://api.loventure.us, https://kibana.loventure.us"
+}
+
+# 클러스터 설정
+variable "cluster_config" {
+  description = "클러스터 설정"
+  type = object({
+    cluster_name = string
+    environment  = string
+  })
+  default = {
+    cluster_name = "pitterpetter-dev-cluster"
+    environment  = "development"
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Google Cloud Provider 설정
+provider "google" {
+  project = var.project_id
+  region  = var.cluster_location
+}
+
+# Kubernetes Provider 설정
+provider "kubernetes" {
+  host  = "https://${data.google_container_cluster.main.endpoint}"
+  token = data.google_client_config.current.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.main.master_auth[0].cluster_ca_certificate
+  )
+}
+
+# Helm Provider 설정
+provider "helm" {
+  kubernetes {
+    host  = "https://${data.google_container_cluster.main.endpoint}"
+    token = data.google_client_config.current.access_token
+    cluster_ca_certificate = base64decode(
+      data.google_container_cluster.main.master_auth[0].cluster_ca_certificate
+    )
+  }
+}


### PR DESCRIPTION
## 📝 목적/배경
- ELK Stack 모니터링 시스템을 Terraform으로 관리할 수 있도록 인프라 코드 추가

## 🔧 주요 작업(변경) 사항
- [x] Terraform 인프라 코드 추가
  - [x] 01-namespace.tf - 모니터링 네임스페이스 생성
  - [x] 02-elasticsearch.tf - Elasticsearch StatefulSet 배포
  - [x] 03-logstash.tf - Logstash Deployment 배포
  - [x] 04-kibana.tf - Kibana Deployment 배포
  - [x] 05-filebeat.tf - Filebeat DaemonSet 배포
  - [x] variables.tf - 변수 정의 
  - [x] outputs.tf - 출력값 정의 
  - [x] monitoring.tfvars - 환경별 설정값
  - [x] versions.tf - Terraform 및 Provider 버전 정의
- [x] Helm values.yaml 파일 업데이트

## 🎥 스크린샷/데모 (선택)

## 🔗 이슈 연결
- PID-468

## ✅ 체크리스트
- [x] merge branch 가 develop 인지 확인
- [x] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타
